### PR TITLE
Fix missing translation on first login on Decidim v0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.0.6.1 (PATCH)
+- Fix missing translation on first login
+
 ## Version 0.0.6 (MINOR)
 - Increase minimum Decidim version to 0.27.6
 - Downgrade Ruby version to 3.0.7

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby RUBY_VERSION
 gemspec
 
 group :development, :test do
+  gem "uri", "0.13.1"
   gem "bootsnap", require: true
   gem "byebug"
   gem "social-share-button"

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ ruby RUBY_VERSION
 gemspec
 
 group :development, :test do
-  gem "uri", "0.13.1"
   gem "bootsnap", require: true
   gem "byebug"
   gem "social-share-button"
+  gem "uri", "0.13.1"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-verifications-members_picker (0.0.6)
+    decidim-verifications-members_picker (0.0.6.1)
       decidim-core (>= 0.27.5)
       decidim-verifications (>= 0.27.5)
       psych (< 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -752,7 +752,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (0.13.1)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -815,6 +815,7 @@ DEPENDENCIES
   social-share-button
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
+  uri (= 0.13.1)
   web-console (~> 3.5)
 
 RUBY VERSION

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -8,4 +8,5 @@ locales: [en, ca, es]
 
 ignore_unused:
   - "decidim.authorization_handlers.members_picker_authorization_handler.*"
+  - "decidim.verifications.authorizations.first_login.*"
   - "decidim.verifications.members_picker_authorization.extra_explanation"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -12,7 +12,7 @@ ca:
       authorizations:
         first_login:
           actions:
-            members_picker_authorization_handler:  Elecció de membres
+            members_picker_authorization_handler: Elecció de membres
       members_picker_authorization:
         extra_explanation: La participació està restringida a només uns participants
           amb permís.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -9,6 +9,10 @@ ca:
           members_picker_help: "(separats per comes)"
         name: Tria quins correus electrònics poden participar al component
     verifications:
+      authorizations:
+        first_login:
+          actions:
+            members_picker_authorization_handler:  Elecció de membres
       members_picker_authorization:
         extra_explanation: La participació està restringida a només uns participants
           amb permís.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
       authorizations:
         first_login:
           actions:
-            members_picker_authorization_handler:  Members picker
+            members_picker_authorization_handler: Members picker
       members_picker_authorization:
         extra_explanation: Participation is restricted to participants with the permitted
           email.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,10 @@ en:
         name: Pick the emails of the users that will be able to participate in the
           current component
     verifications:
+      authorizations:
+        first_login:
+          actions:
+            members_picker_authorization_handler:  Members picker
       members_picker_authorization:
         extra_explanation: Participation is restricted to participants with the permitted
           email.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,6 +9,10 @@ es:
           members_picker_help: "(separado por comas)"
         name: Elige qué correos electrónicos pueden participar en el componente
     verifications:
+      authorizations:
+        first_login:
+          actions:
+            members_picker_authorization_handler:  Elección de miembros
       members_picker_authorization:
         extra_explanation: La participación está restringida a sólo unos participantes
           con permiso

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,7 +12,7 @@ es:
       authorizations:
         first_login:
           actions:
-            members_picker_authorization_handler:  Elección de miembros
+            members_picker_authorization_handler: Elección de miembros
       members_picker_authorization:
         extra_explanation: La participación está restringida a sólo unos participantes
           con permiso

--- a/lib/decidim/verifications/members_picker/version.rb
+++ b/lib/decidim/verifications/members_picker/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module Verifications
     module MembersPicker
       def self.version
-        "0.0.6"
+        "0.0.6.1"
       end
     end
   end


### PR DESCRIPTION
Decidim v0.27 expects that verifiers translate their name for this partial.