### PR TITLE
Fix missing translation on first login on Decidim v0.28

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - release/*
+      - "*-stable"
   pull_request:
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+      - release/*
+      - "*-stable"
+
   pull_request:
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.1.1 (PATCH)
+- Breaking semanting versioning to have one minor for each decidim minor
+- Fix missing translation on first login
+
 ## Version 0.0.7 (MINOR)
 - Increase minimum Decidim version to 0.28
 - Downgrade Ruby version to 3.1.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-verifications-members_picker (0.0.7)
+    decidim-verifications-members_picker (0.1.1)
       decidim-core (>= 0.28.0)
       decidim-verifications (>= 0.28.0)
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -8,4 +8,5 @@ locales: [en, ca, es]
 
 ignore_unused:
   - "decidim.authorization_handlers.members_picker_authorization_handler.*"
+  - "decidim.verifications.authorizations.first_login.*"
   - "decidim.verifications.members_picker_authorization.extra_explanation"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -12,7 +12,7 @@ ca:
       authorizations:
         first_login:
           actions:
-            members_picker_authorization_handler:  Elecció de membres
+            members_picker_authorization_handler: Elecció de membres
       members_picker_authorization:
         extra_explanation: La participació està restringida a només uns participants
           amb permís.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -9,6 +9,10 @@ ca:
           members_picker_help: "(separats per comes)"
         name: Tria quins correus electrònics poden participar al component
     verifications:
+      authorizations:
+        first_login:
+          actions:
+            members_picker_authorization_handler:  Elecció de membres
       members_picker_authorization:
         extra_explanation: La participació està restringida a només uns participants
           amb permís.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
       authorizations:
         first_login:
           actions:
-            members_picker_authorization_handler:  Members picker
+            members_picker_authorization_handler: Members picker
       members_picker_authorization:
         extra_explanation: Participation is restricted to participants with the permitted
           email.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,10 @@ en:
         name: Pick the emails of the users that will be able to participate in the
           current component
     verifications:
+      authorizations:
+        first_login:
+          actions:
+            members_picker_authorization_handler:  Members picker
       members_picker_authorization:
         extra_explanation: Participation is restricted to participants with the permitted
           email.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,6 +9,10 @@ es:
           members_picker_help: "(separado por comas)"
         name: Elige qué correos electrónicos pueden participar en el componente
     verifications:
+      authorizations:
+        first_login:
+          actions:
+            members_picker_authorization_handler:  Elección de miembros
       members_picker_authorization:
         extra_explanation: La participación está restringida a sólo unos participantes
           con permiso

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,7 +12,7 @@ es:
       authorizations:
         first_login:
           actions:
-            members_picker_authorization_handler:  Elección de miembros
+            members_picker_authorization_handler: Elección de miembros
       members_picker_authorization:
         extra_explanation: La participación está restringida a sólo unos participantes
           con permiso

--- a/lib/decidim/verifications/members_picker/version.rb
+++ b/lib/decidim/verifications/members_picker/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module Verifications
     module MembersPicker
       def self.version
-        "0.0.7"
+        "0.1.1"
       end
     end
   end


### PR DESCRIPTION
Decidim expects that verifiers translate their name for this partial.

Port https://github.com/gencat/decidim-verifications-members_picker/pull/9 to Decidim `v0.28`.